### PR TITLE
Added badge next to username in the profile section

### DIFF
--- a/templates/partials/account/header.tpl
+++ b/templates/partials/account/header.tpl
@@ -34,7 +34,7 @@
 		<div class="d-flex flex-column flex-md-row mt-1 justify-content-between w-100 gap-2">
 			<div class="d-flex flex-grow-1 flex-row gap-2">
 				<div class="d-flex flex-column gap-1">
-					<h2 class="fullname fw-semibold fs-2 tracking-tight mb-0">{{{ if fullname }}}{fullname}{{{ else }}}{username}{{{ end }}}</h2>
+					<h2 class="fullname fw-semibold fs-2 tracking-tight mb-0">{{{ if fullname }}}{fullname}{{{ else }}}{username}{{{ end }}}{{{ if reputation }}}📀{{{else}}}💿{{{end}}}</h2>
 					<div class="d-flex flex-wrap gap-1 text-sm align-items-center">
 						<span class="username fw-bold">{{{ if !banned }}}@{username}{{{ else }}}[[user:banned]]{{{ end }}}</span>
 						<div class="d-flex align-items-center gap-1 p-1">


### PR DESCRIPTION
Added badge next to username in the profile section. This is for the user story of adding a badge next to the name when reaching certain milestones. Currently, the next step is to add this badge to multiple locations where the username appears. One thing still in progress which is a bit annoying is that .tpl doesn't allow comparing integers using operations like > and <=, you can only do stuff like ==, !, and && for strings and booleans.