### PR TITLE
Added badge next to username for every post

### DIFF
--- a/templates/partials/topic/post.tpl
+++ b/templates/partials/topic/post.tpl
@@ -24,7 +24,7 @@
 				</a>
 			</div>
 
-			<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+			<a class="fw-bold text-nowrap" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}{{{ if user.reputationSilver }}}💿{{{else}}}📀{{{end}}}</a>
 
 			{{{ each posts.user.selectedGroups }}}
 			{{{ if posts.user.selectedGroups.slug }}}


### PR DESCRIPTION
Added badge next to username for every post. This makes the badge displayable next to the author's username when you view their post. It's done by adding an if statement in the tpl which checks for reputation count and puts the emoji after the username.
![Captureddd](https://github.com/user-attachments/assets/c3671140-eac5-418d-aefc-beed0b010bc0)
